### PR TITLE
add -i to curl to show response headers

### DIFF
--- a/ok2curl/src/main/java/com/moczul/ok2curl/CurlBuilder.java
+++ b/ok2curl/src/main/java/com/moczul/ok2curl/CurlBuilder.java
@@ -88,7 +88,7 @@ public class CurlBuilder {
 
     public String build() {
         List<String> parts = new ArrayList<>();
-        parts.add("curl");
+        parts.add("curl -i");
         parts.add(String.format(FORMAT_METHOD, method.toUpperCase()));
 
         for (String key : headers.keySet()) {

--- a/ok2curl/src/test/java/com/moczul/ok2curl/CurlBuilderTest.java
+++ b/ok2curl/src/test/java/com/moczul/ok2curl/CurlBuilderTest.java
@@ -18,7 +18,7 @@ public class CurlBuilderTest {
         final Request request = new Request.Builder().url("http://example.com/").build();
         final String command = new CurlBuilder(request).build();
 
-        assertEquals("curl -X GET http://example.com/", command);
+        assertEquals("curl -i -X GET http://example.com/", command);
     }
 
     @Test
@@ -29,7 +29,7 @@ public class CurlBuilderTest {
                 .build();
         final String command = new CurlBuilder(request).build();
 
-        assertEquals("curl -X GET -H \"Accept:application/json\" http://example.com/", command);
+        assertEquals("curl -i -X GET -H \"Accept:application/json\" http://example.com/", command);
     }
 
     @Test
@@ -46,7 +46,7 @@ public class CurlBuilderTest {
 
         final String command = new CurlBuilder(request).build();
 
-        assertEquals("curl -X GET -H \"Cache-Control:max-age=86400, only-if-cached\" http://example.com/", command);
+        assertEquals("curl -i -X GET -H \"Cache-Control:max-age=86400, only-if-cached\" http://example.com/", command);
     }
 
     @Test
@@ -54,7 +54,7 @@ public class CurlBuilderTest {
         final Request request = new Request.Builder().url("http://example.com/").post(body()).build();
         final String command = new CurlBuilder(request).build();
 
-        final String expected = "curl -X POST -H \"Content-Type:application/x-www-form-urlencoded\" -d 'key1=value1' http://example.com/";
+        final String expected = "curl -i -X POST -H \"Content-Type:application/x-www-form-urlencoded\" -d 'key1=value1' http://example.com/";
         assertEquals(expected, command);
     }
 
@@ -64,7 +64,7 @@ public class CurlBuilderTest {
         final Request request = new Request.Builder().url("http://example.com/").post(body).build();
         final String command = new CurlBuilder(request).build();
 
-        final String expected = "curl -X POST -d 'StringBody' http://example.com/";
+        final String expected = "curl -i -X POST -d 'StringBody' http://example.com/";
         assertEquals(expected, command);
     }
 


### PR DESCRIPTION
Often times it is useful to see response headers along with response body that's logged by the curl request. This commit should fix for that use-case by adding the -i CLI argument param to the curl request that is printed out by the interceptor.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mrmike/ok2curl/22)

<!-- Reviewable:end -->
