### PR TITLE
Fix deploy script

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-# Go to root directory
-cd ..
-
 # Call bintrayUpload task
 ./gradlew :ok2curl:bintrayUpload
 


### PR DESCRIPTION
* Script is called from the root folder anyway. There's no need to call `cd` command