### PR TITLE
Fix curl when the request url has some special characters

### DIFF
--- a/ok2curl/src/main/java/com/moczul/ok2curl/CurlBuilder.java
+++ b/ok2curl/src/main/java/com/moczul/ok2curl/CurlBuilder.java
@@ -24,6 +24,7 @@ public class CurlBuilder {
     private static final String FORMAT_HEADER = "-H \"%1$s:%2$s\"";
     private static final String FORMAT_METHOD = "-X %1$s";
     private static final String FORMAT_BODY = "-d '%1$s'";
+    private static final String FORMAT_URL = "\"%1$s\"";
     private static final String CONTENT_TYPE = "Content-Type";
 
     private final String url;
@@ -124,7 +125,7 @@ public class CurlBuilder {
             parts.add(String.format(FORMAT_BODY, body));
         }
 
-        parts.add(url);
+        parts.add(String.format(FORMAT_URL, url));
 
         return join(" ", parts);
     }

--- a/ok2curl/src/test/java/com/moczul/ok2curl/CookieHandlerTest.java
+++ b/ok2curl/src/test/java/com/moczul/ok2curl/CookieHandlerTest.java
@@ -87,7 +87,7 @@ public class CookieHandlerTest {
 
         okHttpClient.newCall(request).execute();
 
-        final String expectedCurl = "curl -X GET " + url;
+        final String expectedCurl = String.format("curl -X GET \"%s\"",  url);
         verify(logger).log(expectedCurl);
     }
 

--- a/ok2curl/src/test/java/com/moczul/ok2curl/CurlBuilderTest.java
+++ b/ok2curl/src/test/java/com/moczul/ok2curl/CurlBuilderTest.java
@@ -22,7 +22,7 @@ public class CurlBuilderTest {
 
         final String command = new CurlBuilder(request).build();
 
-        assertEquals("curl -X GET http://example.com/", command);
+        assertEquals("curl -X GET \"http://example.com/\"", command);
     }
 
     @Test
@@ -34,7 +34,7 @@ public class CurlBuilderTest {
 
         final String command = new CurlBuilder(request).build();
 
-        assertEquals("curl -X GET -H \"Accept:application/json\" http://example.com/", command);
+        assertEquals("curl -X GET -H \"Accept:application/json\" \"http://example.com/\"", command);
     }
 
     @Test
@@ -51,7 +51,7 @@ public class CurlBuilderTest {
 
         final String command = new CurlBuilder(request).build();
 
-        assertEquals("curl -X GET -H \"Cache-Control:max-age=86400, only-if-cached\" http://example.com/", command);
+        assertEquals("curl -X GET -H \"Cache-Control:max-age=86400, only-if-cached\" \"http://example.com/\"", command);
     }
 
     @Test
@@ -60,7 +60,7 @@ public class CurlBuilderTest {
 
         final String command = new CurlBuilder(request).build();
 
-        final String expected = "curl -X POST -H \"Content-Type:application/x-www-form-urlencoded\" -d 'key1=value1' http://example.com/";
+        final String expected = "curl -X POST -H \"Content-Type:application/x-www-form-urlencoded\" -d 'key1=value1' \"http://example.com/\"";
         assertEquals(expected, command);
     }
 
@@ -71,7 +71,7 @@ public class CurlBuilderTest {
 
         final String command = new CurlBuilder(request).build();
 
-        final String expected = "curl -X POST -d 'StringBody' http://example.com/";
+        final String expected = "curl -X POST -d 'StringBody' \"http://example.com/\"";
         assertEquals(expected, command);
     }
 
@@ -85,7 +85,7 @@ public class CurlBuilderTest {
 
         final String command = new CurlBuilder(request).build();
 
-        assertEquals("curl -X GET -H \"Cookie:FIRST=foo\" -H \"Cookie:SECOND=bar\" http://example.com/", command);
+        assertEquals("curl -X GET -H \"Cookie:FIRST=foo\" -H \"Cookie:SECOND=bar\" \"http://example.com/\"", command);
     }
 
     @Test
@@ -95,7 +95,7 @@ public class CurlBuilderTest {
 
         final String command = new CurlBuilder(request, 1024, Collections.<HeaderModifier>emptyList(), options).build();
 
-        assertEquals("curl --insecure -X GET http://example.com/", command);
+        assertEquals("curl --insecure -X GET \"http://example.com/\"", command);
     }
 
     @Test
@@ -105,7 +105,7 @@ public class CurlBuilderTest {
 
         final String command = new CurlBuilder(request, 1024, Collections.<HeaderModifier>emptyList(), options).build();
 
-        assertEquals("curl --connect-timeout 120 -X GET http://example.com/", command);
+        assertEquals("curl --connect-timeout 120 -X GET \"http://example.com/\"", command);
     }
 
     private RequestBody body() {

--- a/ok2curl/src/test/java/com/moczul/ok2curl/util/HeaderModifierTest.java
+++ b/ok2curl/src/test/java/com/moczul/ok2curl/util/HeaderModifierTest.java
@@ -52,7 +52,7 @@ public class HeaderModifierTest {
         final List<HeaderModifier> modifiers = Collections.singletonList(cookieHeaderModifier);
         final String command = new CurlBuilder(request, -1L, modifiers, Options.EMPTY).build();
 
-        assertEquals("curl -X GET -H \"Cookie:modifiedCookieValue\" http://example.com/", command);
+        assertEquals("curl -X GET -H \"Cookie:modifiedCookieValue\" \"http://example.com/\"", command);
     }
 
     @Test
@@ -65,7 +65,7 @@ public class HeaderModifierTest {
 
         final String command = new CurlBuilder(request, -1L, modifiers, Options.EMPTY).build();
 
-        assertEquals("curl -X GET -H \"Accept:application/json\" http://example.com/", command);
+        assertEquals("curl -X GET -H \"Accept:application/json\" \"http://example.com/\"", command);
     }
 
     @Test
@@ -79,6 +79,6 @@ public class HeaderModifierTest {
         final List<HeaderModifier> modifiers = Collections.singletonList(nullHeaderModifier);
         final String command = new CurlBuilder(request, -1L, modifiers, Options.EMPTY).build();
 
-        assertEquals(command, "curl -X GET http://example.com/", command);
+        assertEquals(command, "curl -X GET \"http://example.com/\"", command);
     }
 }


### PR DESCRIPTION
Regarding to the curl documentation:
```
 When using [] or {} sequences when invoked from a command line prompt, you probably have to put the full URL within double quotes to avoid the shell from interfering with it. This
       also goes for other characters treated special, like for example '&', '?' and '*'.
```

